### PR TITLE
Fix: Cursor jumps when deleting newline to join lines

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -12,7 +12,7 @@
   - [x] Needs work
 - [x] Enter key should insert a new line
 - [x] Only Render the visible lines
-- [ ] Set cursor position with mouse
+- [x] Set cursor position with mouse
 - [ ] Scrolling
   - [ ] Scroll wheel
   - [ ] Follow cursor

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -440,6 +440,18 @@ By Gholamreza Dar
             }
         }
 
+        if(IsMouseButtonDown(MOUSE_BUTTON_LEFT)){
+            // std::cout << GetMouseX() << std::endl;
+            int y = GetMouseY();
+            y /= editor.gridHeight + editor.verticalLineSpacing;
+            cursorPosition.y = y > editorData.getNumLines() - 1 ? editorData.getNumLines() - 1 : y;
+
+            int x = GetMouseX();// / (int)editor.gridWidth) * (int)editor.gridWidth  + editor.windowPadding;
+            x /= editor.gridWidth;
+            cursorPosition.x = x;
+            // std::cout << GetMouseY() << std::endl;
+        }
+
         // Working grid (this is a grid that every character can be placed on)
         if (true)
         {


### PR DESCRIPTION
Before this fix, performing a delete operation that merged two lines (for example, hitting Backspace at the start of a line to join it with the previous one, or Delete at the end of a line to merge it with the next) caused the cursor to jump to an incorrect and often unexpected position. 