### PR TITLE
Feat only render the visible lines

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -11,7 +11,7 @@
 - [x] Delete text at cursor (backspace)
   - [x] Needs work
 - [x] Enter key should insert a new line
-- [ ] Only Render the visible lines
+- [x] Only Render the visible lines
 - [ ] Set cursor position with mouse
 - [ ] Scrolling
   - [ ] Scroll wheel

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -278,14 +278,14 @@ By Gholamreza Dar
                             int lineNumber = cursorPosition.y;
                             if (lineNumber > 0)
                             {
+                                // move the cursor up
+                                cursorPosition.y = MAX(0, cursorPosition.y - 1);
+                                // move the cursor to the end of the line
+                                cursorPosition.x = editor.lineNumberWidth + editor.spaceBetweenNumbersAndText + editorData.lines[cursorPosition.y].length();
                                 // merge this line with the previous one
                                 editorData.lines[lineNumber - 1] = editorData.lines[lineNumber - 1] + editorData.lines[lineNumber];
                                 // delete the line
                                 editorData.lines.erase(editorData.lines.begin() + lineNumber);
-                                // move the cursor up
-                                cursorPosition.y = MAX(0, cursorPosition.y - 1);
-                                // move the cursor to the end of the line
-                                cursorPosition.x = editorData.lines[cursorPosition.y].length() + editor.lineNumberWidth + editor.spaceBetweenNumbersAndText;
                             }
                         }
                     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -488,10 +488,12 @@ By Gholamreza Dar
                 float x = editor.windowPadding;
                 float y = i * editor.verticalLineSpacing +
                           i * editor.gridHeight + editor.windowPadding;
+
                 std::string line_number_text =
                     leftPad(std::to_string(i + 1), editor.lineNumberWidth);
                 DrawTextEx(font, line_number_text.c_str(), Vector2{x, y},
                            editor.fontSize, 0, editor.editorLineNumbersColor);
+                if (y >= GetScreenHeight()) break;
             }
         }
 
@@ -505,6 +507,8 @@ By Gholamreza Dar
                           editor.gridWidth * (editor.lineNumberWidth + 2);
                 float y = i * editor.verticalLineSpacing +
                           i * editor.gridHeight + editor.windowPadding;
+                if (y >= GetScreenHeight())
+                    break;
                 std::string line_text = editorData.getLine(i);
                 DrawTextEx(font, line_text.c_str(), Vector2{x, y},
                            editor.fontSize, 0, editor.editorTextColor);


### PR DESCRIPTION
This feature introduces a mechanism to only render the lines that are currently visible within the editor's viewport. (without scroll support).

Please accept the first PR before this, to avoid conflicts.