### PR TITLE
fix: position offset

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -13,7 +13,7 @@
 - [x] Enter key should insert a new line
 - [x] Only Render the visible lines
 - [x] Set cursor position with mouse
-  - [ ] Is off by a few pixels
+  - [x] Is off by a few pixels (fixed by subtracting editors window padding.)
 - [ ] Scrolling
   - [ ] Scroll wheel
   - [ ] Follow cursor

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -443,10 +443,12 @@ By Gholamreza Dar
         if(IsMouseButtonDown(MOUSE_BUTTON_LEFT)){
             // std::cout << GetMouseX() << std::endl;
             int y = GetMouseY();
+            y -= editor.windowPadding;
             y /= editor.gridHeight + editor.verticalLineSpacing;
             cursorPosition.y = y > editorData.getNumLines() - 1 ? editorData.getNumLines() - 1 : y;
 
             int x = GetMouseX();// / (int)editor.gridWidth) * (int)editor.gridWidth  + editor.windowPadding;
+            x-= editor.windowPadding;
             x /= editor.gridWidth;
             cursorPosition.x = x;
             // std::cout << GetMouseY() << std::endl;


### PR DESCRIPTION
Previously, when attempting to set the cursor's position by clicking with the mouse, the cursor would frequently appear at an incorrect offset from the clicked location. 